### PR TITLE
Audio recording source set to high quality source

### DIFF
--- a/app/src/main/java/freed/cam/apis/basecamera/record/VideoRecorder.java
+++ b/app/src/main/java/freed/cam/apis/basecamera/record/VideoRecorder.java
@@ -147,7 +147,8 @@ public class VideoRecorder {
                 if (this.currentVideoProfile.isAudioActive)
                 {
                     try {
-                        mediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
+                        mediaRecorder.setAudioSource(MediaRecorder.AudioSource.CAMCORDER);
+                        //mediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
                         //mediaRecorder.setAudioEncoder(currentVideoProfile.audioCodec);
                     }
                     catch (IllegalArgumentException ex)


### PR DESCRIPTION
I've set it to CAMCORDER because it is camera audio source with stereo mic. 
DEFAULT uses the call mic that actively enables noise cancellation with  mono audio recording. 

I've previously posted a video on youtube because of a bug related to this in MI A1 OS https://www.youtube.com/watch?v=-DaW5b6mlcY.