### PR TITLE
Fix: Video Underexpose / Flickering on First Focus while recording.

### DIFF
--- a/app/src/main/java/freed/cam/apis/basecamera/parameters/AbstractParameterHandler.java
+++ b/app/src/main/java/freed/cam/apis/basecamera/parameters/AbstractParameterHandler.java
@@ -178,7 +178,7 @@ public abstract class AbstractParameterHandler
         setManualMode(SettingKeys.M_ExposureCompensation,true);
     }
 
-    protected void SetParameters()
+    public void SetParameters()
     {}
 
     private void setMode(ParameterInterface parameter, String settings_key)

--- a/app/src/main/java/freed/cam/apis/camera1/modules/AbstractVideoModule.java
+++ b/app/src/main/java/freed/cam/apis/camera1/modules/AbstractVideoModule.java
@@ -153,6 +153,12 @@ public abstract class AbstractVideoModule extends ModuleAbstract implements Medi
                 recorder.prepare();
                 Log.d(TAG, "Recorder Prepared, Starting Recording");
                 recorder.start();
+
+                //fix exposer flick after video recording on first set parameters to camera.
+                // first call will under expose then second call will fix exposure.
+                cameraUiWrapper.getParameterHandler().SetParameters();
+                cameraUiWrapper.getParameterHandler().SetParameters();
+
                 Log.d(TAG, "Recording started");
                 sendStartToUi();
 

--- a/app/src/main/java/freed/cam/apis/camera1/parameters/ParametersHandler.java
+++ b/app/src/main/java/freed/cam/apis/camera1/parameters/ParametersHandler.java
@@ -122,7 +122,7 @@ public class ParametersHandler extends AbstractParameterHandler
     }
 
     @Override
-    protected void SetParameters() {
+    public void SetParameters() {
         SetParametersToCamera(cameraParameters);
     }
 


### PR DESCRIPTION
I've set Camera Parameters two times immediately after recording start call "recorder.start();". The first call will underexpose and second call will set to normal again. and then continues to  record videos.

Now on first thouch focus event the video will not go under expose or no flickering will happen.