### PR TITLE
"Geo-Tag Location" Settings Check for DNG Capture Camera1 API

### DIFF
--- a/app/src/main/java/freed/cam/apis/camera1/modules/PictureModule.java
+++ b/app/src/main/java/freed/cam/apis/camera1/modules/PictureModule.java
@@ -303,7 +303,8 @@ public class PictureModule extends ModuleAbstract implements Camera.PictureCallb
             task.setOrientation(cameraUiWrapper.getActivityInterface().getOrientation());
         task.setFilePath(file, SettingsManager.getInstance().GetWriteExternal());
         task.setBytesTosave(data,ImageSaveTask.RAW10);
-        task.setLocation(cameraUiWrapper.getActivityInterface().getLocationManager().getCurrentLocation());
+        if (!SettingsManager.get(SettingKeys.LOCATION_MODE).get().equals(SettingsManager.getInstance().getResString(R.string.off_)))
+            task.setLocation(cameraUiWrapper.getActivityInterface().getLocationManager().getCurrentLocation());
         ImageManager.putImageSaveTask(task);
     }
 }


### PR DESCRIPTION
The condition was checked in Camera2 API but not present in camera1 API.

